### PR TITLE
Fix minor bugs in GO-Elite: Mm MPhenoOntology and Hs WikiPathways parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
+mpmath/**/*.pyc
+*.pyc
 *.zip

--- a/GeneSetDownloader.py
+++ b/GeneSetDownloader.py
@@ -486,7 +486,7 @@ def importPhenotypeOntologyGeneAssociations():
         t = string.split(data,'\t')
         hs_symbol=t[0]; hs_entrez=t[1]; mm_symbol=t[2]; mgi=t[3]; pheno_ids=t[4]
         if 'MP' not in pheno_ids:
-            try: pheno_ids = t[5]
+            try: mm_symbol=t[3]; mgi=t[4]; pheno_ids=t[5]
             except Exception: pass
         hs_symbol = string.lower(hs_symbol)
         mm_symbol = string.lower(mm_symbol)

--- a/gene_associations.py
+++ b/gene_associations.py
@@ -1349,7 +1349,7 @@ class GeneIDInfo:
         except Exception: null=[]
     def GeneID(self): return str(self.geneID)
     def System(self): return str(self.system_name)
-    def Pathway(self): return str(self.pathway)
+    def Pathway(self): return self.pathway ## Returning str() threw an error for non-ASCII characters in HsWikiPathways
     def setGraphID(self,graphID): self.graphID = graphID
     def setGroupID(self,groupid): self.groupid = groupid
     def GraphID(self): return self.graphID
@@ -1396,6 +1396,7 @@ def exportWikiPathwayData(species_name,pathway_db,type):
         values +=[wpd.Uniprot(), wpd.Unigene(), wpd.Refseq(), wpd.MOD(), wpd.Pubchem(), wpd.CAS(), wpd.Chebi()]
         values = string.join(values,'\t')
         values = string.replace(values,'\n','') ###Included by mistake
+        values = values.encode('UTF-8', 'replace') ## Need this line to prevent non-ASCII characters from HsWikiPathways throwing an error
         export_data.write(values+'\n')
     export_data.close()
     #print 'WikiPathways data exported to:',export_dir


### PR DESCRIPTION
Hi,

I'm attempting to use the GO-Elite tool, even though it's old, because of its featured ability to handle the issue of gene ontology terms overlapping. In the course of trying to use it, I came across some bugs in the code that prevented me from using it to its fullest extent. It's likely that these bugs came about with more recent additions of the respective databases, but I wanted to bring these to your attention with my suggested changes to the code. If you want, I can open up issues to detail how the error occurred.

Best,
Warren